### PR TITLE
feat: add CLI and container support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build:cli
+RUN npm prune --omit=dev
+
+# Runtime stage
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package*.json ./
+ENTRYPOINT ["node", "dist/cli.js"]

--- a/README.md
+++ b/README.md
@@ -143,3 +143,18 @@ Start the development server:
 ```bash
 npm run dev
 ```
+
+## Command line
+
+The checker can also be run from the command line or in a container:
+
+```bash
+# Run locally after building
+ogc-checker <spec> <file>
+
+# Or use the provided Dockerfile
+docker build -t ogc-checker .
+docker run --rm -v "$PWD":/data ogc-checker <spec> /data/<file>
+```
+
+The command exits with code `0` when all checks pass and a non‑zero code otherwise.

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import process from 'process';
+import { Spectral, Document, RulesetDefinition } from '@stoplight/spectral-core';
+import { Json } from '@stoplight/spectral-parsers';
+import jsonFgRulesets from './src/specs/json-fg/rulesets/index.js';
+import ogcApiRulesets from './src/specs/ogc-api/rulesets/index.js';
+
+const usage = `Usage: ogc-checker <spec> <file>\n\n` +
+  `Available specs: json-fg, ogc-api-features, ogc-api-processes, ogc-api-records`;
+
+function getRulesets(spec: string): [string, RulesetDefinition][] | undefined {
+  switch (spec) {
+    case 'json-fg':
+      return Object.entries(jsonFgRulesets);
+    case 'ogc-api-features':
+      return Object.entries(ogcApiRulesets).filter(([k]) =>
+        k.startsWith('http://www.opengis.net/spec/ogcapi-features-')
+      );
+    case 'ogc-api-processes':
+      return Object.entries(ogcApiRulesets).filter(([k]) =>
+        k.startsWith('http://www.opengis.net/spec/ogcapi-processes-')
+      );
+    case 'ogc-api-records':
+      return Object.entries(ogcApiRulesets).filter(([k]) =>
+        k.startsWith('http://www.opengis.net/spec/ogcapi-records-')
+      );
+    default:
+      return undefined;
+  }
+}
+
+async function main() {
+  const [, , spec, file] = process.argv;
+  if (!spec || !file) {
+    console.error(usage);
+    process.exit(1);
+  }
+
+  const rulesets = getRulesets(spec);
+  if (!rulesets) {
+    console.error(`Unknown spec: ${spec}`);
+    console.error(usage);
+    process.exit(1);
+  }
+
+  const content = fs.readFileSync(file, 'utf-8');
+  const document = new Document(content, Json);
+
+  let hasErrors = false;
+  for (const [name, ruleset] of rulesets) {
+    const spectral = new Spectral();
+    spectral.setRuleset(ruleset);
+    const results = await spectral.run(document);
+    if (results.length > 0) {
+      hasErrors = true;
+      for (const v of results) {
+        const start = v.range.start;
+        const end = v.range.end;
+        const loc = `${start.line + 1}:${start.character + 1}-${end.line + 1}:${end.character + 1}`;
+        console.log(`${name}: [${v.code}] ${v.message} (${loc})`);
+      }
+    }
+  }
+
+  if (!hasErrors) {
+    console.log('No issues found');
+  }
+
+  process.exit(hasErrors ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "bin": {
+    "ogc-checker": "dist/cli.js"
+  },
   "scripts": {
     "dev": "vite --open",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && npm run build:cli && vite build",
+    "build:cli": "tsc -p tsconfig.cli.json && echo '{\"type\":\"commonjs\"}' > dist/package.json",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest"

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["cli.ts", "src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- add Node-based CLI for checking JSON-FG and OGC API specs
- provide Dockerfile for containerized usage
- document CLI usage

## Testing
- `npm test` *(fails: connect ENETUNREACH 217.154.65.51:443 - Local (0.0.0.0:0))*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890a8bf408c8333bdb65f7c9f0b0c6c